### PR TITLE
Upgraded dependencies as per npm audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
-    "coveralls": "^2.13.1",
+    "coveralls": "^3.0.2",
     "eslint": "^2.13.1",
     "eslint-config-airbnb": "^9.0.0",
     "eslint-plugin-import": "^1.7.0",
@@ -54,7 +54,7 @@
     "eslint-plugin-react": "^5.0.1",
     "istanbul": "^1.0.0-alpha.2",
     "joi": "^10.2.2",
-    "mocha": "^2.4.5"
+    "mocha": "^5.2.0"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
Only two package warnings: `coveralls` and `mocha`
1. All tests pass
> 5 passing (408ms)
> ===== Coverage summary =====
> Statements   : 100% ( 6/6 )
> Branches     : 100% ( 4/4 )
> Functions    : 100% ( 1/1 )
> Lines        : 100% ( 6/6 )
2. Coveralls reporting correctly: https://coveralls.io/builds/19149643
[![Coverage Status](https://coveralls.io/repos/github/SafetyCulture/joi-verhoeff/badge.svg?branch=dependency-update)](https://coveralls.io/github/SafetyCulture/joi-verhoeff?branch=dependency-update)